### PR TITLE
Fix MinuteRange and SecondRange in the same day and hour

### DIFF
--- a/lib/src/widget/datetime_picker_widget.dart
+++ b/lib/src/widget/datetime_picker_widget.dart
@@ -618,7 +618,7 @@ class _DateTimePickerWidgetState extends State<DateTimePickerWidget> {
     if (_currYear == _maxTime.year &&
         _currMonth == _maxTime.month &&
         _currDay == _maxTime.day &&
-        _currHour == _minTime.hour) {
+        _currHour == _maxTime.hour) {
       // selected maximum day、hour, limit minute range
       maxMinute = _maxTime.minute;
     }
@@ -647,8 +647,8 @@ class _DateTimePickerWidgetState extends State<DateTimePickerWidget> {
     if (_currYear == _maxTime.year &&
         _currMonth == _maxTime.month &&
         _currDay == _maxTime.day &&
-        _currHour == _minTime.hour &&
-        _currMinute == _minTime.minute) {
+        _currHour == _maxTime.hour &&
+        _currMinute == _maxTime.minute) {
       // selected maximum hour and minute, limit second range
       maxSecond = _maxTime.second;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cupertino_datetime_picker
 description: Fork from flutter_cupertino_date_picker https://github.com/wuzhendev/flutter-cupertino-date-picker, but year, month, day seperate
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/ykrank/flutter_cupertino_datetime_picker
 
 dependencies:


### PR DESCRIPTION
Currently, when the same date and hour are specified for minDateTime and maxDateTime of a DateTimePickerWidget, maxMinute returns maxDateTime.minute  when currHour == minTime.hour, and that returns "59" when currHour == maxTime.hour.
(MaxSecond is also returns incorrect value with same reason.)

This fix includes
* Fixed _calcMinuteRange when minDateTime and maxDateTime are the same day and Hour.
* Fixed _calcSecondRange when minDateTime and maxDateTime are the same day, same Hour, and same Minute